### PR TITLE
Remove incorrect/misleading parenthetical clause

### DIFF
--- a/_episodes/05-history.md
+++ b/_episodes/05-history.md
@@ -117,7 +117,7 @@ In this way,
 we can build up a chain of commits.
 The most recent end of the chain is referred to as `HEAD`;
 we can refer to previous commits using the `~` notation,
-so `HEAD~1` (pronounced "head minus one")
+so `HEAD~1`
 means "the previous commit",
 while `HEAD~123` goes back 123 commits from where we are now.
 


### PR DESCRIPTION
When reviewing this lesson, I was surprised to see the suggestion to pronounce "HEAD~1" as "head minus one". If anything, it should just be pronounced "head tilde one". I can only imagine the other pronunciation confusing learners. I did some Googling and couldn't find anybody else calling it "head minus one".  Since this is such an easy change, I just went ahead and implemented it, rather than making an issue.